### PR TITLE
Now it's checked if pidfile PID exists as program also

### DIFF
--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -32,7 +32,7 @@ if [[ -n "$PID" ]]
 then
   if ps -p "$PID" > /dev/null
   then
-    exit 0
+    start_server
   fi
 fi
 


### PR DESCRIPTION
When tmc-cli process doesn't exists but pid file exists, server is started again because of unsynced information 