### PR TITLE
Configfiles are no longer written to project root for linux, mac, freebsd and windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ tmc-langs.log
 config.properties
 cache
 /pihlantesti/viikko1/Viikko1_004.Muuttujat/nbproject/private/
+/tmc-testcourse/most_errors/nbproject/private/

--- a/scripts/tmc
+++ b/scripts/tmc
@@ -180,9 +180,7 @@ function login () {
 
 # Backend cmd send
 function send_command () {
-    DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-
-    CONFIGPATH="$DIR/config.properties"
+    CONFIGPATH="$XDG_CONFIG_HOME/tmc/config.properties"
     if [ -f "$CONFIGPATH" ];
     then
       CONFIGPORT=$(grep "serverPort" < "$CONFIGPATH" | sed s/serverPort=//g)
@@ -202,9 +200,7 @@ function send_command () {
 }
 
 function send_command_wait_output () {
-    DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-
-    CONFIGPATH="$DIR/config.properties"
+    CONFIGPATH="$XDG_CONFIG_HOME/tmc/config.properties"
     CONFIGPORT=$(grep "serverPort" < "$CONFIGPATH" | sed s/serverPort=//g)
     OUTPUT=$(echo "$@" | nc localhost "$CONFIGPORT")
 
@@ -235,9 +231,7 @@ then
     exit
 fi
 
-DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-CONFIGPATH="$DIR/config.properties"
-
+CONFIGPATH="$XDG_CONFIG_HOME/tmc/config.properties"
 
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )

--- a/src/main/java/hy/tmc/cli/TmcCli.java
+++ b/src/main/java/hy/tmc/cli/TmcCli.java
@@ -22,7 +22,7 @@ public class TmcCli {
 
     public TmcCli(TmcCore core) throws IOException {
         this.core = core;
-        this.config = new ConfigHandler("config.properties");
+        this.config = new ConfigHandler();
         this.session = new Session();
         server = new Server(this);
         serverThread = new Thread(server);

--- a/src/main/java/hy/tmc/cli/configuration/ConfigHandler.java
+++ b/src/main/java/hy/tmc/cli/configuration/ConfigHandler.java
@@ -176,7 +176,7 @@ public class ConfigHandler {
 
     private void createConfigFileIfMissing() throws IOException {
         if (!Files.exists(configFilePath.toAbsolutePath().getParent())) {
-            Files.createDirectories(configFilePath.toAbsolutePath());
+            Files.createDirectories(configFilePath.toAbsolutePath().getParent());
         }
         if (!Files.exists(configFilePath, LinkOption.NOFOLLOW_LINKS)) {
             Files.createFile(configFilePath);

--- a/src/main/java/hy/tmc/cli/configuration/ConfigHandler.java
+++ b/src/main/java/hy/tmc/cli/configuration/ConfigHandler.java
@@ -6,6 +6,10 @@ import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.InputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -16,18 +20,20 @@ import java.util.Properties;
  */
 public class ConfigHandler {
 
-    private String configFilePath;
-    private String portFieldName = "serverPort";
-    private String serverAddressFieldName = "serverAddress";
-    private String lastUpdate = "lastUpdate";
+    private Path configFilePath;
+    private final String portFieldName = "serverPort";
+    private final String serverAddressFieldName = "serverAddress";
+    private final String lastUpdate = "lastUpdate";
+    private EnvironmentWrapper environment;
 
     private SimpleDateFormat sdf = new SimpleDateFormat("dd-M-yyyy HH:mm:ss");
 
     /**
      * Creates new config handler with default filename and path in current directory.
      */
-    public ConfigHandler() {
-        this.configFilePath = "config.properties";
+    public ConfigHandler() throws IOException {
+        this.configFilePath = this.getConfigDirectory().resolve("config.properties");
+        createConfigFileIfMissing();
     }
 
     /**
@@ -35,21 +41,21 @@ public class ConfigHandler {
      *
      * @param path for config file
      */
-    public ConfigHandler(String path) {
+    public ConfigHandler(Path path) {
         this.configFilePath = path;
     }
 
     public String getConfigFilePath() {
-        return configFilePath;
+        return configFilePath.toString();
     }
 
     public void setConfigFilePath(String configFileName) {
-        this.configFilePath = configFileName;
+        this.configFilePath = Paths.get(configFileName);
     }
 
     private Properties getProperties() {
         Properties prop = new Properties();
-        File propertyFile = new File(configFilePath);
+        File propertyFile = configFilePath.toFile();
         try {
             if (!propertyFile.exists()) {
                 propertyFile.createNewFile();
@@ -67,7 +73,7 @@ public class ConfigHandler {
     private void writeData(String property, String data) throws IOException {
         Properties prop = getProperties();
         prop.setProperty(property, data);
-        FileWriter writer = new FileWriter(new File(configFilePath));
+        FileWriter writer = new FileWriter(configFilePath.toFile());
         prop.store(writer, "Updated properties");
         writer.close();
     }
@@ -119,7 +125,7 @@ public class ConfigHandler {
     public Date readLastUpdate() throws ParseException, IOException {
         Properties prop = getProperties();
         String dateInString = prop.getProperty(lastUpdate);
-        if(isNullOrEmpty(dateInString)){
+        if (isNullOrEmpty(dateInString)) {
             Date d = new Date();
             this.writeLastUpdate(d);
             return d;
@@ -137,5 +143,23 @@ public class ConfigHandler {
     public void writeLastUpdate(Date lastUpdate) throws IOException {
         String date = sdf.format(lastUpdate);
         writeData("lastUpdate", date);
+    }
+
+    private Path getConfigDirectory() {
+        if (environment.getOsName().equals("Linux")) {
+            return Paths.get(environment.getenv("XDG_CONFIG_HOME"), "tmc");
+        } else if (environment.getOsName().toLowerCase().contains("mac os x")) {
+            return Paths.get("");
+        } else if (environment.getOsName().toLowerCase().contains("windows")) {
+            return Paths.get("");
+        }
+        return Paths.get("");
+    }
+
+    private void createConfigFileIfMissing() throws IOException {
+        Files.createDirectories(configFilePath.toAbsolutePath());
+        if (!Files.exists(configFilePath, LinkOption.NOFOLLOW_LINKS)) {
+            Files.createFile(configFilePath);
+        }
     }
 }

--- a/src/main/java/hy/tmc/cli/configuration/ConfigHandler.java
+++ b/src/main/java/hy/tmc/cli/configuration/ConfigHandler.java
@@ -32,6 +32,7 @@ public class ConfigHandler {
      * Creates new config handler with default filename and path in current directory.
      */
     public ConfigHandler() throws IOException {
+        environment = new EnvironmentWrapper();
         this.configFilePath = this.getConfigDirectory().resolve("config.properties");
         createConfigFileIfMissing();
     }
@@ -43,6 +44,16 @@ public class ConfigHandler {
      */
     public ConfigHandler(Path path) {
         this.configFilePath = path;
+    }
+
+    /**
+     * For testing.
+     *
+     * @param mock enables testing of multiple platforms.
+     */
+    public ConfigHandler(EnvironmentWrapper mock) {
+        this.environment = mock;
+        this.configFilePath = this.getConfigDirectory().resolve("config.properties");
     }
 
     public String getConfigFilePath() {
@@ -157,7 +168,9 @@ public class ConfigHandler {
     }
 
     private void createConfigFileIfMissing() throws IOException {
-        Files.createDirectories(configFilePath.toAbsolutePath());
+        if (!Files.exists(configFilePath.toAbsolutePath().getParent())) {
+            Files.createDirectories(configFilePath.toAbsolutePath());
+        }
         if (!Files.exists(configFilePath, LinkOption.NOFOLLOW_LINKS)) {
             Files.createFile(configFilePath);
         }

--- a/src/main/java/hy/tmc/cli/configuration/ConfigHandler.java
+++ b/src/main/java/hy/tmc/cli/configuration/ConfigHandler.java
@@ -1,5 +1,6 @@
 package hy.tmc.cli.configuration;
 
+import com.google.common.base.Strings;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import java.io.File;
 import java.io.FileInputStream;
@@ -157,14 +158,20 @@ public class ConfigHandler {
     }
 
     private Path getConfigDirectory() {
-        if (environment.getOsName().equals("Linux")) {
-            return Paths.get(environment.getenv("XDG_CONFIG_HOME"), "tmc");
-        } else if (environment.getOsName().toLowerCase().contains("mac os x")) {
-            return Paths.get("");
+        if (isUnixLikePlatform()) {
+            return Paths.get(xdgConfigFolder(), "tmc");
         } else if (environment.getOsName().toLowerCase().contains("windows")) {
             return Paths.get(environment.getenv("APPDATA"), "tmc");
         }
         return Paths.get("");
+    }
+
+    private String xdgConfigFolder() {
+        String xdgConf = environment.getenv("XDG_CONFIG_HOME");
+        if (Strings.isNullOrEmpty(xdgConf)) {
+            return environment.getHomeDirectory() + File.separatorChar + ".config";
+        }
+        return xdgConf;
     }
 
     private void createConfigFileIfMissing() throws IOException {
@@ -174,5 +181,10 @@ public class ConfigHandler {
         if (!Files.exists(configFilePath, LinkOption.NOFOLLOW_LINKS)) {
             Files.createFile(configFilePath);
         }
+    }
+
+    private boolean isUnixLikePlatform() {
+        String osname = environment.getOsName().toLowerCase();
+        return osname.equals("linux") || osname.contains("mac os x") || osname.contains("freebsd");
     }
 }

--- a/src/main/java/hy/tmc/cli/configuration/ConfigHandler.java
+++ b/src/main/java/hy/tmc/cli/configuration/ConfigHandler.java
@@ -162,7 +162,7 @@ public class ConfigHandler {
         } else if (environment.getOsName().toLowerCase().contains("mac os x")) {
             return Paths.get("");
         } else if (environment.getOsName().toLowerCase().contains("windows")) {
-            return Paths.get("");
+            return Paths.get(environment.getenv("APPDATA"), "tmc");
         }
         return Paths.get("");
     }

--- a/src/main/java/hy/tmc/cli/configuration/EnvironmentWrapper.java
+++ b/src/main/java/hy/tmc/cli/configuration/EnvironmentWrapper.java
@@ -10,4 +10,8 @@ public class EnvironmentWrapper {
     public String getOsName() {
         return System.getProperty("os.name");
     }
+
+    public String getHomeDirectory() {
+        return System.getProperty("user.home");
+    }
 }

--- a/src/main/java/hy/tmc/cli/configuration/EnvironmentWrapper.java
+++ b/src/main/java/hy/tmc/cli/configuration/EnvironmentWrapper.java
@@ -1,0 +1,13 @@
+package hy.tmc.cli.configuration;
+
+
+public class EnvironmentWrapper {
+
+    public String getenv(String s) {
+        return System.getenv(s);
+    }
+    
+    public String getOsName() {
+        return System.getProperty("os.name");
+    }
+}

--- a/src/test/java/hy/tmc/cli/configuration/ConfigHandlerTest.java
+++ b/src/test/java/hy/tmc/cli/configuration/ConfigHandlerTest.java
@@ -13,14 +13,19 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.text.ParseException;
 import java.util.Date;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ConfigHandlerTest {
 
     ConfigHandler handler;
     String address = "http://boss.fi";
+    EnvironmentWrapper env;
 
     @Before
     public void setup() {
+        env = mock(EnvironmentWrapper.class);
         handler = new ConfigHandler(Paths.get("test.properties"));
     }
 
@@ -29,26 +34,38 @@ public class ConfigHandlerTest {
         assertEquals("test.properties", handler.getConfigFilePath());
         new File("test.properties").delete();
     }
-    
+
     @Test
     public void testConfigPathIsCorrectForLinux() {
-
+        String xdgConf = "home/duck/.config";
+        when(env.getOsName()).thenReturn("Linux");
+        when(env.getenv(eq("XDG_CONFIG_HOME"))).thenReturn(xdgConf);
+        String path = new ConfigHandler(env).getConfigFilePath();
+        String expected = xdgConf + File.separatorChar + "tmc" + File.separatorChar + "config.properties";
+        assertEquals(expected, path);
     }
-    
+
     @Test
     public void testConfigPathIsCorrectForMac() {
+        when(env.getOsName()).thenReturn("Mac OS X");
+        String path = new ConfigHandler(env).getConfigFilePath();
+        assertEquals("config.properties", path);
     }
-    
+
     @Test
     public void testConfigPathIsCorrectForWindows() {
-
+        when(env.getOsName()).thenReturn("Windows 10");
+        String path = new ConfigHandler(env).getConfigFilePath();
+        assertEquals("config.properties", path);
     }
-    
+
     @Test
     public void testConfigPathIsCorrectForOther() {
-
+        when(env.getOsName()).thenReturn("Fantasmas Minuscul-os");
+        String path = new ConfigHandler(env).getConfigFilePath();
+        assertEquals("config.properties", path);
     }
-    
+
     /**
      * Clean all marks of test in config files.
      */
@@ -60,7 +77,8 @@ public class ConfigHandlerTest {
             if (file.exists()) {
                 file.delete();
             }
-        } catch (IOException ex) {
+        }
+        catch (IOException ex) {
             fail("something went wrong");
         }
     }
@@ -68,7 +86,8 @@ public class ConfigHandlerTest {
     private void writeServerAddress(String address) {
         try {
             handler.writeServerAddress(address);
-        } catch (IOException ex) {
+        }
+        catch (IOException ex) {
             fail("Something went wrong");
         }
     }
@@ -81,7 +100,7 @@ public class ConfigHandlerTest {
         assertEquals(handler.readServerAddress(), "http://einiinboss.fi");
     }
 
-    @Test (expected = IllegalStateException.class)
+    @Test(expected = IllegalStateException.class)
     public void exceptionIsThrownIfNoAddressFound() {
         handler.readServerAddress();
     }
@@ -90,7 +109,8 @@ public class ConfigHandlerTest {
     public void canWriteAddressToConfig() {
         try {
             handler.writeServerAddress(address);
-        } catch (IOException ex) {
+        }
+        catch (IOException ex) {
             fail("Something went wrong");
         }
     }
@@ -99,34 +119,37 @@ public class ConfigHandlerTest {
     public void canReadAddressFromConfig() {
         try {
             handler.writeServerAddress(address);
-        } catch (IOException ex) {
+        }
+        catch (IOException ex) {
             fail("Failed writing to file");
         }
         String readAddress = handler.readServerAddress();
         assertEquals(readAddress, address);
     }
-    
+
     @Test
     public void canWritePortAddress() {
         try {
             handler.writePort(1234);
-        } catch (IOException ex) {
+        }
+        catch (IOException ex) {
             fail("failed to write port");
         }
     }
-    
+
     @Test
     public void dontCrashWhenLastUpdateDoesntExist() throws ParseException, IOException {
         Date lastUpdate = handler.readLastUpdate();
         assertNotNull(lastUpdate);
     }
-    
+
     @Test
     public void correctPortGetsWritten() {
         try {
             handler.writePort(12355);
             assertEquals(12355, handler.readPort());
-        } catch (IOException ex) {
+        }
+        catch (IOException ex) {
             fail("Failed to read or write port");
         }
     }

--- a/src/test/java/hy/tmc/cli/configuration/ConfigHandlerTest.java
+++ b/src/test/java/hy/tmc/cli/configuration/ConfigHandlerTest.java
@@ -2,7 +2,6 @@ package hy.tmc.cli.configuration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import org.junit.After;
@@ -11,6 +10,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.text.ParseException;
 import java.util.Date;
 
@@ -21,13 +21,32 @@ public class ConfigHandlerTest {
 
     @Before
     public void setup() {
-        handler = new ConfigHandler("test.properties");
+        handler = new ConfigHandler(Paths.get("test.properties"));
     }
 
     @Test
     public void configPathIsSetCorrectly() {
         assertEquals("test.properties", handler.getConfigFilePath());
         new File("test.properties").delete();
+    }
+    
+    @Test
+    public void testConfigPathIsCorrectForLinux() {
+
+    }
+    
+    @Test
+    public void testConfigPathIsCorrectForMac() {
+    }
+    
+    @Test
+    public void testConfigPathIsCorrectForWindows() {
+
+    }
+    
+    @Test
+    public void testConfigPathIsCorrectForOther() {
+
     }
     
     /**

--- a/src/test/java/hy/tmc/cli/configuration/ConfigHandlerTest.java
+++ b/src/test/java/hy/tmc/cli/configuration/ConfigHandlerTest.java
@@ -54,9 +54,12 @@ public class ConfigHandlerTest {
 
     @Test
     public void testConfigPathIsCorrectForWindows() {
+        String appdata = "C:\\asdf\\bsdfg";
         when(env.getOsName()).thenReturn("Windows 10");
+        when(env.getenv(eq("APPDATA"))).thenReturn(appdata);
         String path = new ConfigHandler(env).getConfigFilePath();
-        assertEquals("config.properties", path);
+        String expected = appdata + File.separatorChar + "tmc" + File.separatorChar + "config.properties";
+        assertEquals(expected, path);
     }
 
     @Test

--- a/src/test/java/hy/tmc/cli/configuration/ConfigHandlerTest.java
+++ b/src/test/java/hy/tmc/cli/configuration/ConfigHandlerTest.java
@@ -34,6 +34,17 @@ public class ConfigHandlerTest {
         assertEquals("test.properties", handler.getConfigFilePath());
         new File("test.properties").delete();
     }
+    
+    @Test
+    public void testXdgDefaultsCorrectly() {
+        String xdgConf = "home/duck/.config";
+        when(env.getOsName()).thenReturn("Mac OS X");
+        when(env.getenv(eq("XDG_CONFIG_HOME"))).thenReturn("");
+        when(env.getHomeDirectory()).thenReturn("home/duck");
+        String path = new ConfigHandler(env).getConfigFilePath();
+        String expected = xdgConf + File.separatorChar + "tmc" + File.separatorChar + "config.properties";
+        assertEquals(expected, path);
+    }
 
     @Test
     public void testConfigPathIsCorrectForLinux() {
@@ -47,9 +58,22 @@ public class ConfigHandlerTest {
 
     @Test
     public void testConfigPathIsCorrectForMac() {
+        String xdgConf = "home/duck/.config";
         when(env.getOsName()).thenReturn("Mac OS X");
+        when(env.getenv(eq("XDG_CONFIG_HOME"))).thenReturn(xdgConf);
         String path = new ConfigHandler(env).getConfigFilePath();
-        assertEquals("config.properties", path);
+        String expected = xdgConf + File.separatorChar + "tmc" + File.separatorChar + "config.properties";
+        assertEquals(expected, path);
+    }
+    
+    @Test
+    public void testConfigPathIsCorrectForFreeBsd() {
+        String xdgConf = "home/duck/.config";
+        when(env.getOsName()).thenReturn("FreeBsd");
+        when(env.getenv(eq("XDG_CONFIG_HOME"))).thenReturn(xdgConf);
+        String path = new ConfigHandler(env).getConfigFilePath();
+        String expected = xdgConf + File.separatorChar + "tmc" + File.separatorChar + "config.properties";
+        assertEquals(expected, path);
     }
 
     @Test

--- a/src/test/java/hy/tmc/cli/frontend/communication/server/ServerTest.java
+++ b/src/test/java/hy/tmc/cli/frontend/communication/server/ServerTest.java
@@ -77,7 +77,7 @@ public class ServerTest {
     }
 
     @Test
-    public void testGetCurrentPort() {
+    public void testGetCurrentPort() throws IOException {
         int result = server.getCurrentPort();
         assertEquals(new ConfigHandler().readPort(), result);
     }


### PR DESCRIPTION
linux mac and freebsd use the xdg specification, windows uses the appdata folder.